### PR TITLE
Remove pollux.json dependency

### DIFF
--- a/src/structures/util/PolluxClient.js
+++ b/src/structures/util/PolluxClient.js
@@ -1,8 +1,7 @@
 const axios = require('axios')
 
 module.exports = class PolluxClient {
-  constructor (data = require('../../../pollux.json')) {
-    this.data = data
+  constructor () {
     this.userGame = new Map()
 
     /**
@@ -102,11 +101,11 @@ module.exports = class PolluxClient {
 
   request (path, field, parameters = {}) {
     return axios({
-      url: (this.data[field] + path),
+      url: (process.env["POLLUX_" + field.toUpperCase()] + path),
       params: parameters,
       method: 'GET',
       headers: {
-        'User-Agent': this.data.useragent
+        'User-Agent': process.env.POLLUX_USER_AGENT
       },
       responseType: (path.includes('generator') ? 'arraybuffer' : 'json'),
       paramsSerializer: (params) => {


### PR DESCRIPTION
Pollux-specific configuration fields should now be included in environment variables instead of the `pollux.json` file.